### PR TITLE
Send auth password via POST as needed by Pi-Hole API (v4.4)

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -6,7 +6,7 @@ import sys
 from enum import IntEnum
 from http.client import HTTPResponse
 from urllib.parse import urlencode, urlunparse, ParseResult
-from urllib.request import urlopen
+import urllib.request
 
 class ListType(IntEnum):
     WHITELIST = 1
@@ -32,8 +32,13 @@ class Host:
         params. If auth is True, the call is authenticated with the host's
         webpassword.
         """
+
+
+        post_params = {}
+
         if auth:
-            query_params['auth'] = self.webpassword
+            post_params = {'pw' : self.webpassword}
+
         components = ParseResult(
             scheme = 'http',
             netloc = self.address,
@@ -43,7 +48,10 @@ class Host:
             fragment = ''
         )
         url = urlunparse(components)
-        return urlopen(url)
+        data = urllib.parse.urlencode(post_params).encode("utf-8")
+        req = urllib.request.Request(url, data)
+
+        return urllib.request.urlopen(req)
 
     def get_list(self, list_type):
         """


### PR DESCRIPTION
This change fixes this script to work with the current version of the Pi-Hole API.

I'm not sure when, but at some point they appear to have changed from sending the password in the URL Query Parameter `auth` to requiring that it be sent in a POST parameter `pw`.

This has been verified to work on my Pi-Hole instances, running the following versions, in Docker containers using `pihole/pihole:latest` as of the time of this post.

* Pi-hole Version v4.4
* Web Interface Version v4.3.3
* FTL Version v4.3.1